### PR TITLE
docs: Update README to TestMu AI template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,111 @@
-# Running NightWatch Script on LambdaTest
+# Run NightWatch Selenium Tests via CircleCI on TestMu AI (Formerly LambdaTest)
 
-##### [NightWatch Documentation](http://nightwatchjs.org/)
-![LAMBDATEST Logo](http://labs.lambdatest.com/images/fills-copy.svg)
+<p align="center">
+  <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
+  <a href="https://nightwatchjs.org/"><img src="https://img.shields.io/badge/NightWatch-Selenium-green.svg?style=for-the-badge&labelColor=000" alt="NightWatch Selenium"></a>
+  <a href="https://community.testmuai.com/"><img src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&labelColor=000000" alt="Community"></a>
+</p>
 
+## Getting Started
 
-### Environment Setup
+[TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks. 
 
-1. Global Dependencies
-    * Install [Node.js](https://nodejs.org/en/)
-    * Or Install Node.js with [Homebrew](http://brew.sh/)
-    ```
-    $ brew install node
-    ```
-2. lambdatest Credentials
-    * In the terminal export your lambdatest Credentials as environmental variables:
-    ```
-    $ export LT_USERNAME=<your lambdatest username>
-    $ export LT_ACCESS_KEY=<your lambdatest access_key>
-    ```
-3. Project Dependencies
-    * Install Node modules
-    ```
-    $ npm install
-    ```
+With TestMu AI (Formerly LambdaTest), you can run NightWatch Selenium tests via CircleCI across real browsers and operating systems. This sample shows how to configure NightWatch to run on the TestMu AI cloud.
 
-### Running Tests
+- [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
+- Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.
 
-* Tests in Parallel:
+### Prerequisites
 
-    ** Linux/Mac
-    
-    ```
-    $ ./node_modules/.bin/nightwatch -e chrome,edge tests
-    ```
-    
-   ** Windows
-    ```
-    $ node_modules\.bin\nightwatch -e chrome,edge tests
+- [Node.js](https://nodejs.org/en/) installed on your system.
+- A TestMu AI (Formerly LambdaTest) account. [Sign up here](https://www.testmuai.com/register/).
+- Your TestMu AI Username and Access Key from your [profile page](https://accounts.lambdatest.com/detail/profile).
+
+### Setup
+
+1. Clone this repository:
+    ```bash
+    git clone https://github.com/LambdaTest/Nightwatch-circleci-selenium
+    cd Nightwatch-circleci-selenium
     ```
 
-You will see the test result in the [Lambdatest Dashboard](https://automation.lambdatest.com)
+2. Export your TestMu AI credentials as environment variables:
+    ```bash
+    export LT_USERNAME=<your lambdatest username>
+    export LT_ACCESS_KEY=<your lambdatest access_key>
+    ```
 
-###  Routing traffic through your local machine
-- Set tunnel value to `True` in test capabilities
-> OS specific instructions to download and setup tunnel binary can be found at the following links.
->    - [Windows](https://www.lambdatest.com/support/docs/display/TD/Local+Testing+For+Windows)
->    - [Mac](https://www.lambdatest.com/support/docs/display/TD/Local+Testing+For+MacOS)
->    - [Linux](https://www.lambdatest.com/support/docs/display/TD/Local+Testing+For+Linux)
+3. Install Node modules:
+    ```bash
+    npm install
+    ```
 
-### Important Note:
----
-- Some Safari & IE browsers, doesn't support automatic resolution of the URL string "localhost". Therefore if you test on URLs like "http://localhost/" or "http://localhost:8080" etc, you would get an error in these browsers. A possible solution is to use "localhost.lambdatest.com" or replace the string "localhost" with machine IP address. For example if you wanted to test "http://localhost/dashboard" or, and your machine IP is 192.168.2.6 you can instead test on "http://192.168.2.6/dashboard" or "http://localhost.lambdatest.com/dashboard".
+### Run tests
 
-## About LambdaTest
+Run tests in parallel:
 
-[LambdaTest](https://www.lambdatest.com/) is a cloud based selenium grid infrastructure that can help you run automated cross browser compatibility tests on 2000+ different browser and operating system environments. LambdaTest supports all programming languages and frameworks that are supported with Selenium, and have easy integrations with all popular CI/CD platforms. It's a perfect solution to bring your [selenium automation testing](https://www.lambdatest.com/selenium-automation) to cloud based infrastructure that not only helps you increase your test coverage over multiple desktop and mobile browsers, but also allows you to cut down your test execution time by running tests on parallel.
+- Linux/Mac:
+    ```bash
+    ./node_modules/.bin/nightwatch -e chrome,edge tests
+    ```
+- Windows:
+    ```
+    node_modules\.bin\nightwatch -e chrome,edge tests
+    ```
 
-### Resources
+View results in the [TestMu AI Automation Dashboard](https://automation.lambdatest.com).
 
-##### [SeleniumHQ Documentation](http://www.seleniumhq.org/docs/)
+> **Note:** Some Safari and IE browsers do not support automatic resolution of the URL string "localhost". If you test on URLs like `http://localhost/` or `http://localhost:8080`, you may get an error in these browsers. Use `localhost.lambdatest.com` or replace `localhost` with your machine's IP address instead.
+
+### Local testing with TestMu AI Tunnel
+
+To test locally hosted apps, set up the TestMu AI tunnel. OS-specific guides:
+
+- [Local Testing on Windows](https://www.testmuai.com/support/docs/local-testing-for-windows/)
+- [Local Testing on macOS](https://www.testmuai.com/support/docs/local-testing-for-macos/)
+- [Local Testing on Linux](https://www.testmuai.com/support/docs/local-testing-for-linux/)
+
+Set the `tunnel` capability to `true` in your NightWatch test configuration to route browser traffic through the TestMu AI tunnel to your locally hosted app.
+
+## Contributions
+
+Contributions are welcome. Open an issue to discuss your idea before submitting a pull request. When reporting bugs, include your Node.js version, OS, and Angular CLI version.
+
+## TestMu AI (Formerly LambdaTest) Community
+
+Connect with testers and developers in the [TestMu AI Community](https://community.testmuai.com/). Ask questions, share what you are building, and discuss best practices in test automation and DevOps.
+  
+## TestMu AI (Formerly LambdaTest) Certifications
+
+Earn free [TestMu AI Certifications](https://www.testmuai.com/certifications/) for testers, developers, and QA engineers. Validate your skills in Selenium, Cypress, Playwright, Appium, Espresso and more. Industry-recognized, shareable on LinkedIn, and built by practitioners, not marketers.
+
+## Learning Resources by TestMu AI (Formerly LambdaTest)
+
+Learn modern testing through tutorials, guides, videos, and weekly updates:
+
+* [TestMu AI Blog](https://www.testmuai.com/blog/)
+* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/)
+* [TestMu AI on YouTube](https://www.youtube.com/@TestMuAI)
+* [TestMu AI Newsletter](https://www.testmuai.com/newsletter/)
+  
+## LambdaTest is Now TestMu AI
+
+On **January 12, 2026**, [LambdaTest evolved to TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/), the world's first fully autonomous **Agentic AI Quality Engineering Platform**.
+
+Same team. Same infrastructure. Same customer accounts. All existing LambdaTest logins, scripts, capabilities, and integrations continue to work without change.
+
+ð Find the new home for [LambdaTest](https://www.testmuai.com).
+
+### How LambdaTest Evolved into TestMu AI
+
+In 2017, we launched LambdaTest with a simple mission: make testing fast, reliable, and accessible. As LambdaTest grew, we expanded into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the full depth of the testing lifecycle.
+
+As software development entered the AI era, testing had to evolve, too. We rebuilt the architecture to be AI-native from the ground up, with autonomous agents that **plan, author, execute, analyze, and optimize tests** while keeping humans in the loop. The platform integrates with your repos, CI, IDEs, and terminals, continuously learning from every code change and development signal.
+
+That evolution earned a new name: **TestMu AI**, built for an AI-first future of quality engineering. TestMu is not a new name for us. It is the name of our annual community conference, which has brought together 100,000+ quality engineers to discuss how AI would reshape testing, long before that became an industry norm. 
+
+What started as a high-performance cloud testing platform has transformed into an AI-native, multi-agent system powering a connected, end-to-end quality layer. That evolution defined a new identity: LambdaTest evolved into TestMu AI, built for an AI-first future of quality engineering.
+
+## Support
+
+Got a question? Email [support@testmuai.com](mailto:support@testmuai.com) or chat with us 24x7 from our chat portal.


### PR DESCRIPTION
Updates README to follow the standard TestMu AI (Formerly LambdaTest) template.