### PR TITLE
fix: Clean up README links and titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Run NightWatch Selenium Tests via CircleCI on TestMu AI (Formerly LambdaTest)
+﻿# Run NightWatch Selenium Tests via CircleCI on TestMu AI (Formerly LambdaTest)
 
 <p align="center">
   <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
@@ -17,9 +17,9 @@ With TestMu AI (Formerly LambdaTest), you can run NightWatch Selenium tests via 
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/en/) installed on your system.
-- A TestMu AI (Formerly LambdaTest) account. [Sign up here](https://www.testmuai.com/register/).
-- Your TestMu AI Username and Access Key from your [profile page](https://accounts.lambdatest.com/detail/profile).
+- Node.js installed on your system.
+- A TestMu AI (Formerly LambdaTest) account. Sign up here.
+- Your TestMu AI Username and Access Key from your profile page.
 
 ### Setup
 
@@ -53,7 +53,7 @@ Run tests in parallel:
     node_modules\.bin\nightwatch -e chrome,edge tests
     ```
 
-View results in the [TestMu AI Automation Dashboard](https://automation.lambdatest.com).
+View results in the TestMu AI Automation Dashboard.
 
 > **Note:** Some Safari and IE browsers do not support automatic resolution of the URL string "localhost". If you test on URLs like `http://localhost/` or `http://localhost:8080`, you may get an error in these browsers. Use `localhost.lambdatest.com` or replace `localhost` with your machine's IP address instead.
 


### PR DESCRIPTION
Removes non-template hyperlinks from Prerequisites, Setup, and Run tests sections. Fixes H1 title where needed.