### PR TITLE
fix: update README branding and remove non-template links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ With TestMu AI (Formerly LambdaTest), you can run NightWatch Selenium tests via 
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/en/) installed on your system.
-- A TestMu AI (Formerly LambdaTest) account. [Sign up here](https://www.testmuai.com/register/).
-- Your TestMu AI Username and Access Key from your [profile page](https://accounts.lambdatest.com/detail/profile).
+- Node.js installed on your system.
+- A TestMu AI (Formerly LambdaTest) account. Sign up here.
+- Your TestMu AI Username and Access Key from your profile page.
 
 ### Setup
 
@@ -53,7 +53,7 @@ Run tests in parallel:
     node_modules\.bin\nightwatch -e chrome,edge tests
     ```
 
-View results in the [TestMu AI Automation Dashboard](https://automation.lambdatest.com).
+View results in the TestMu AI Automation Dashboard.
 
 > **Note:** Some Safari and IE browsers do not support automatic resolution of the URL string "localhost". If you test on URLs like `http://localhost/` or `http://localhost:8080`, you may get an error in these browsers. Use `localhost.lambdatest.com` or replace `localhost` with your machine's IP address instead.
 


### PR DESCRIPTION
- Replace standalone LambdaTest with TestMu AI (Formerly LambdaTest) in body text\n- Remove non-template links from Prerequisites/Setup/Run tests sections